### PR TITLE
Adding all previously made installation scripts

### DIFF
--- a/install_and_run_scripts/README.md
+++ b/install_and_run_scripts/README.md
@@ -1,0 +1,18 @@
+# ROS_launch_scripts
+
+This repository contains all launch scripts required to run the Franka Gazebo Simulation.
+
+### Guidelines
+
+- All the paths should be with respect to a base folder
+- I know some paths need to be hard coded, they are to be declared on top
+- All scripts should be in zsh. Don't forget to install shell linter. 
+
+The repository should be cloned just inside the catkin work space, within same level there should be src, build, devel, install
+
+### Usage:
+
+- ./launch_franka_simulations.zsh (For running all your simulations)
+- ./build_all_packages.zsh (For building everything and catkin_make from scratch)
+
+Good Luck!

--- a/install_and_run_scripts/build_all_packages.bash
+++ b/install_and_run_scripts/build_all_packages.bash
@@ -1,0 +1,70 @@
+#!/bin/bash
+# The above line is required for shellcheck which is a great linter, to parse
+# the script and interpret it as a bash not zsh, it's a hack and it works
+# CATKIN_WORKSPACE will be used as path where the path script resides
+CATKIN_WORKSPACE=$(pwd)
+LIBFRANKA_BUILD_DIR=$CATKIN_WORKSPACE/src/libfranka/build
+# Activate sources
+source /opt/ros/melodic/setup.bash
+# Install all the dependencies required
+rosdep install --from-paths src --ignore-src -y --skip-keys libfranka
+rosdep install --from-paths src --ignore-src -y --skip-keys ros_robotic_skin
+# I don't know why but rosdep doesn't install the below package which is required
+# Raise an issue for that maybe?
+sudo apt install ros-melodic-imu-filter-madgwick
+sudo apt install ros-melodic-effort-controllers
+# End installing
+if [ -d "src/libfranka/build" ]; then
+    echo "libfranka build already exists. Good!"
+else
+  cd src/libfranka
+  git submodule update --init
+  mkdir build
+  cd "$CATKIN_WORKSPACE"
+fi
+if ! cd src/libfranka/build; then
+  echo "cd to libfranka not possible. Something went wrong, check if build directory was created in libfranka"
+fi
+echo "in libfranka build directory"
+# Delete all files to make a clean install homie!
+if ! rm -rf * ; then
+    echo "Unable to delete files in libfranks build. Exiting..."
+    exit 1
+fi
+if ! cmake -DCMAKE_BUILD_TYPE=Release .. ; then
+    echo "Unable to generate make files for libfranka, maybe some dependency missing? Check logs above. Exiting..."
+    exit 1
+fi
+if ! make ; then
+    echo "Unable to build libfranka, maybe some missing dependency? Exiting..."
+    exit 1
+fi
+# All good, lets run catkin_make
+if ! cmake .. ; then
+    echo "Unable to generate make files for libfranka, maybe some dependency missing? Check logs above. Exiting..."
+    exit 1
+fi
+if ! cd $CATKIN_WORKSPACE ; then
+    echo "cd to catkin workspace failed, you might be running the script at wrong place"
+    exit 1
+fi
+if ! catkin_make -j4 -DCMAKE_BUILD_TYPE=Release -DFranka_DIR:PATH=$LIBFRANKA_BUILD_DIR ; then
+    echo "cd to catkin workspace failed, you might be running the script at wrong place"
+    exit 1
+fi
+if [ -d "$CATKIN_WORKSPACE/build" ]; then
+  rm -rf "$CATKIN_WORKSPACE/build"
+  echo "Deleted build"
+fi
+
+if [ -d "$CATKIN_WORKSPACE/devel" ]; then
+  rm -rf "$CATKIN_WORKSPACE/devel"
+  echo "Deleted devel"
+fi
+
+if [ -d "$CATKIN_WORKSPACE/install" ]; then
+  rm -rf "$CATKIN_WORKSPACE/install"
+  echo "Deleted install"
+fi
+# Finally do catk make install
+catkin_make install

--- a/install_and_run_scripts/full_uninstall_ros.bash
+++ b/install_and_run_scripts/full_uninstall_ros.bash
@@ -1,0 +1,5 @@
+#!/bin/bash
+sudo apt remove --purge ros-*
+sudo apt purge --auto-remove ros-melodic-desktop-full
+sudo rm -rf /etc/ros
+echo "I guess ROS is now fully removed, check if any files exist in /opt/ros and then dont forget to restart"

--- a/install_and_run_scripts/get_me_catkin_environment.bash
+++ b/install_and_run_scripts/get_me_catkin_environment.bash
@@ -1,0 +1,6 @@
+#!/bin/bash
+CATKIN_WORKSPACE=$(pwd)
+PROJECT_DEVEL_SETUP=$CATKIN_WORKSPACE/devel/setup.bash
+source ~/.bashrc
+source /opt/ros/melodic/setup.bash
+source "$PROJECT_DEVEL_SETUP"

--- a/install_and_run_scripts/launch_franka_simulation.bash
+++ b/install_and_run_scripts/launch_franka_simulation.bash
@@ -1,0 +1,13 @@
+#!/bin/bash
+# The above line is required for shellcheck which is a great linter, to parse
+# the script and interpret it as a bash not zsh, it's a hack and it works
+# I hope zsh will provide a good linter, I despertely need one, it's an awesome
+# shell, but God gave just shellcheck for now, so gotta djust homie!
+# CATKIN_WORKSPACE will be used as path where the path script resides
+CATKIN_WORKSPACE=$(pwd)
+PROJECT_DEVEL_SETUP="$CATKIN_WORKSPACE"/devel/setup.bash
+gnome-terminal -- ./launch_gazebo.bash
+# sleep 50
+# gnome-terminal -- ./imu_listener.zsh
+# gnome-terminal -- ./launch_activation_matrix.zsh
+# gnome-terminal -- ./joint_movement.zsh

--- a/install_and_run_scripts/launch_gazebo.bash
+++ b/install_and_run_scripts/launch_gazebo.bash
@@ -1,0 +1,9 @@
+#!/bin/bash
+# shellcheck shell=bash
+CATKIN_WORKSPACE=$(pwd)
+PROJECT_DEVEL_SETUP=$CATKIN_WORKSPACE/devel/setup.bash
+source ~/.bashrc
+source /opt/ros/melodic/setup.bash
+source "$PROJECT_DEVEL_SETUP"
+source /usr/share/gazebo/setup.sh
+roslaunch ros_robotic_skin simulation.launch

--- a/install_and_run_scripts/launch_rosjuggler.bash
+++ b/install_and_run_scripts/launch_rosjuggler.bash
@@ -1,0 +1,9 @@
+#!/bin/bash
+# The above line is required for shellcheck which is a great linter, to parse
+# the script and interpret it as a bash not zsh, it's a hack and it works
+# I hope zsh will provide a good linter, I despertely need one, it's an awesome
+# shell, but God gave just shellcheck for now, so gotta djust homie!
+# CATKIN_WORKSPACE will be used as path where the path script resides
+CATKIN_WORKSPACE=$(pwd)
+PROJECT_DEVEL_SETUP="$CATKIN_WORKSPACE"/devel/setup.bash
+rosrun plotjuggler PlotJuggler


### PR DESCRIPTION
So I took out from my personal repo so README.md needs to be changed a bit
- Add each script usefulness to README
- when launching gazebo launch in different terminal the same as I do, when you want to see the logs of what's happening it will be useful at that time. Having everything cluttered and running in the same terminal ain't good. 
- The install script needs to be modified a little bit, to add freedom to install from apt or from source. For me, just source worked best all time
- TODO: Add rosinstall like here: https://github.com/RethinkRobotics/sawyer_robot/blob/master/sawyer_robot.rosinstall keep rosinstall in the root folder

This folder should be a haven to usual commands we daily execute, i.e. on how to launch ROS Juggler