### PR TITLE
Fix Controller Switching

### DIFF
--- a/scripts/controllers/RobotControllerManager.py
+++ b/scripts/controllers/RobotControllerManager.py
@@ -75,11 +75,14 @@ class RobotControllerManager():
             pass
         else:
             try:
-                rospy.wait_for_service(self.switch_controller_service_name)
-                switch_controller = rospy.ServiceProxy(self.switch_controller_service_name, SwitchController)
-                # switch the controllers
-                switch_controller(self.controller_names[desired_mode],
-                                  self.controller_names[self.mode], 1, True, 10)
+                while 1:
+                    rospy.wait_for_service(self.switch_controller_service_name)
+                    switch_controller = rospy.ServiceProxy(self.switch_controller_service_name, SwitchController)
+                    # switch the controllers
+                    resp = switch_controller(self.controller_names[desired_mode],
+                                      self.controller_names[self.mode], 1, True, 10)
+                    if resp.ok:
+                        break
 
                 self.mode = desired_mode
             except rospy.ServiceException as e:

--- a/scripts/controllers/RobotControllerManager.py
+++ b/scripts/controllers/RobotControllerManager.py
@@ -80,7 +80,8 @@ class RobotControllerManager():
                     switch_controller = rospy.ServiceProxy(self.switch_controller_service_name, SwitchController)
                     # switch the controllers
                     resp = switch_controller(self.controller_names[desired_mode],
-                                      self.controller_names[self.mode], 1, True, 10)
+                                             self.controller_names[self.mode], 1, True, 10)
+                    # Break from while loop is response is Okay meaning the switching was successful
                     if resp.ok:
                         break
 


### PR DESCRIPTION
With the recent fork of my ROS controller that you are using, this code is necessary for effective switching. 

I have added a response which the ROS controller manager gives out. If the switch is successful True is returned, else False is returned. When False is returned you should switch again till the controller is right and what is expected.

Before the response code wasn't taken into consideration as a proof of accurate switching. When the controller freezes the response to resp.okay will be False. In previous code, you just used to consider that switch is complete which in matter of fact didn't. This code will take that into consideration and only break the while loop after the switching is complete

This is crucial for data collection scripts to work efficiently.

Thanks!